### PR TITLE
Adds Laravel Helpers package for compatibility with Laravel 5.7 and greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "onelogin/php-saml": "^3.1"
+        "onelogin/php-saml": "^3.1",
+        "laravel/helpers": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "onelogin/php-saml": "^3.1",
-        "laravel/helpers": "^1.1"
+        "onelogin/php-saml": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,10 @@ Features:
 Next, publish the configuration file:
 
     artisan vendor:publish --provider='ZiffDavis\Laravel\Onelogin\OneloginServiceProvider'
+    
+### Note for Laravel 5.7+
+
+If your application uses Laravel 5.7 or greater, please make sure to this package is updated to v0.0.7 or greater.
 
 # Configuration & Setup
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Next, publish the configuration file:
     
 ### Note for Laravel 5.7+
 
-If your application uses Laravel 5.7 or greater, please make sure to this package is updated to v0.0.7 or greater.
+If your application uses Laravel 5.7 or greater, please make sure this package is updated to v0.0.7 or greater.
 
 # Configuration & Setup
 

--- a/src/Middleware/OneloginCsrfDisablerMiddleware.php
+++ b/src/Middleware/OneloginCsrfDisablerMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace ZiffDavis\Laravel\Onelogin\Middleware;
 
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Router;
@@ -21,7 +22,7 @@ class OneloginCsrfDisablerMiddleware
 
     public function __invoke($request, \Closure $next)
     {
-        $csrfMiddlewareClass = array_first($this->router->gatherRouteMiddleware($this->router->getCurrentRoute()), function ($middleware) {
+        $csrfMiddlewareClass = Arr::first($this->router->gatherRouteMiddleware($this->router->getCurrentRoute()), function ($middleware) {
             return in_array(VerifyCsrfToken::class, class_parents($middleware));
         });
 

--- a/src/OneloginServiceProvider.php
+++ b/src/OneloginServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace ZiffDavis\Laravel\Onelogin;
 
+use Illuminate\Support\Arr;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
@@ -17,7 +18,7 @@ class OneloginServiceProvider extends ServiceProvider
 
         $router->middlewareGroup('onelogin', [Middleware\OneloginCsrfDisablerMiddleware::class]);
 
-        $middlewares = array_wrap(config('onelogin.routing.middleware'));
+        $middlewares = Arr::wrap(config('onelogin.routing.middleware'));
 
         $router->group([
             'namespace' => 'ZiffDavis\Laravel\Onelogin\Controllers',


### PR DESCRIPTION
Laravel removed the string and array helper functions like "array_first" in version 5.7, but moved the functions to their own package for backward compatibility. 

By adding the package to the composer.json file, it should ensure users are able to install the laravel-onelogin package regardless of the Laravel version.

By the way, great package. Very useful wrapper!